### PR TITLE
fix: fixing the path of importing font family

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,7 +5,7 @@
 
 @font-face {
   font-family: "Neufile";
-  src: url('../public//assets/font/NeufileGrotesk-Regular.eot');
+  src: url('../public/assets/font/NeufileGrotesk-Regular.eot');
 }
 
 


### PR DESCRIPTION


###  PR DESCRIPTION

- This PR fixed the issue in importing font which had a wrong path

### TASKS COMPLETED

- [x] Fixing path


### HOW CAN THIS PR BE TESTED

```
git clone https://github.com/TheGymRwanda/unit8-maroon
git checkout ft/fixing-font-path
npm install
npm run dev

```


### BEFORE SUBMITTING YOUR PR, ENSURE IT HAS THE FOLLOWING

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard to understand areas
- [x] My changes generate no new warnings

### TICKET NUMBER

#022  https://www.notion.so/apeunit/fb25b4b58d4a4e4d905078c1b7c2af3e